### PR TITLE
WIP: flowchart (aka NodeGraph) visualization

### DIFF
--- a/environment/environment.yml
+++ b/environment/environment.yml
@@ -7,3 +7,4 @@ dependencies:
     - opencv-python==4.7.0.68
     - numpy==1.25.0
     - qtpy>=2.0.0
+    - NodeGraphQt

--- a/src/cvnodegraph.py
+++ b/src/cvnodegraph.py
@@ -1,0 +1,62 @@
+import re
+from qtpy.QtWidgets import QDockWidget
+from NodeGraphQt import (
+    NodeGraph,
+    PropertiesBinWidget,
+    NodesTreeWidget,
+    NodesPaletteWidget
+)
+
+from NodeGraphQt import BaseNode
+# from examples.nodes import basic_nodes
+
+
+# UI: create the widget wrapper that can be docked to the main window.
+class NodeGraphPanel(QDockWidget):
+    """
+    Widget wrapper for the node graph that can be docked to
+    the main window.
+    """
+    def __init__(self, graph, parent=None):
+        super(NodeGraphPanel, self).__init__(parent)
+        self.setObjectName('nodeGraphQt.NodeGraphPanel')
+        self.setWindowTitle('CV2 pipeline visualisation')
+        self.setWidget(graph.widget)
+
+# utils
+def slugify(s):
+    return re.sub(r'[^a-z0-9-]', r'', s.lower()).replace('-', '_')
+
+# Below individual NodeGraph default constructor (1-in => 1-out)
+def node_constructor(self):
+    BaseNode.__init__(self)
+    self.add_input('in A')
+    self.add_output('out A')
+
+class CvNodeGraph():
+    def __init__(self, main_window):
+        self.main_window = main_window
+        self.graph = graph = NodeGraph()
+        self.panel = NodeGraphPanel(graph)
+
+        for key, value in self.main_window.transformer.commands.items():
+            if 'inputs' in value:
+                # Defines dynamic class input/output/colors/labels based on `commands.txt`
+                pass
+            else:
+                # A default class for command with simple 1-in/1-out
+                cls = type(slugify(key), (BaseNode, ), {
+                    # acts as a namespace
+                    "__identifier__": 'nodes.transform',
+                    "NODE_NAME": key,
+                    "__init__": node_constructor
+                })
+                print("register", cls)
+                graph.register_node(cls)
+
+
+    def add_node(self, pipelineitem):
+        key = 'nodes.transform' + '.' + slugify(pipelineitem.transformation_item.name)
+        print("adding node to graph:", key)
+        self.graph.create_node(key, text_color='#feab20')
+

--- a/src/main.py
+++ b/src/main.py
@@ -13,6 +13,7 @@ from transformer import Transformer
 from clickableframe import ClickableFrame
 from pipelineitem import PipelineItem
 from pipeline import Pipeline
+from cvnodegraph import CvNodeGraph
 from sliderwithtext import SliderWithText
 from menuwithtext import MenuWithText
 
@@ -33,6 +34,7 @@ class MainWindow(QMainWindow):
         self.pipeline = Pipeline(self.transformer, self.display_error_message)
         self.transformer_manager = TransformerManager(self, self.pipeline, self.transformer)
         self.index_current_img = -1
+        self.nodegraph = CvNodeGraph(self)
 
         self.setGeometry(100, 100, 700, 700)
         self.initiate_frames()
@@ -130,6 +132,7 @@ class MainWindow(QMainWindow):
         self.btn_download_image.clicked.connect(self.action_download_current_image)
         self.btn_download_image.hide()
         self.pipeline_manage_layout.addWidget(self.btn_download_image)
+        self.addDockWidget(Qt.RightDockWidgetArea, self.nodegraph.panel)
         
         btn_change_current = QRadioButton("Change next")
         self.btn_add_after = QRadioButton("Add")

--- a/src/transformermanager.py
+++ b/src/transformermanager.py
@@ -20,6 +20,7 @@ class TransformerManager():
         self.main_window.index_current_img += 1
         if is_current_last:
             self.pipeline.append(new_item)
+            self.main_window.nodegraph.add_node(new_item)
         elif add_after:
             self.pipeline.insert(self.main_window.index_current_img, new_item)
         elif not add_after:


### PR DESCRIPTION
Building a flowchart to visualize (and hopefully control) command's graph to open the doors of more complex multiple IN/OUT workflow is a must-have (using [NodeGraphQt](http://chantonic.com/NodeGraphQt/api/index.html))

![Screenshot from 2023-11-12 00-21-46](https://github.com/ArthurDelannoyazerty/OpenCV-GUI/assets/1169926/3edd7726-5bdd-475d-b80c-c80b9c0aae3e)

It's a major feature of ala [ImagePlay](http://cpvrlab.github.io/ImagePlay/) : 
![IPL](https://d4.alternativeto.net/QhrDcKKPc5sBIN7TqaIXETzEjWjFZi8_a1iRaaOtvYM/rs:fit:2400:2400:0/g:ce:0:0/YWJzOi8vZGlzdC9zL2ltYWdlcGxheV82OTYxNzdfZnVsbC5wbmc.jpg)



This allows to apply transformations expecting multiple inputs (eg: a custom kernel + image or multiple input images), transformation providing multiple outputs (eg: different channels or region of interest + transformed image) and enjoin branching (trying multiplee paths variation/combination) 


A solid flowchart UX + and a nice CV2 command-description using best introspective Python features would pave the way to a really nice OpenCV UI and make a small code-base easier to build upon than [rather unmaintained these days] ImagePlay)
I wish the [7k LoC of core CV2 <-> UI mapping](https://github.com/cpvrlab/ImagePlay/tree/master/IPL/src/processes) (including multiple in/out handling) could be reimplemented in a mostly declarative `commands.txt` using advanced Python libraries/language constructs (#10 ?)


Regarding this PR, it aimed to be a minimally intrusive PoC provided on it's own distinct branch... but NodeGraph dependency actually uses `qtpy` instead of `PySide6` (see pr #7 and #8)


I believe the flowchart could be the main UI instead of just "listening" to the button (as currently done in this PoC) and each element [could](http://chantonic.com/NodeGraphQt/api/examples/ex_node.html#embedding-custom-widgets) show a live preview of the image.


Happy to further discuss it.

